### PR TITLE
Add community partials layout to fix hardcoded contribution guideline link

### DIFF
--- a/layouts/partials/community_links.html
+++ b/layouts/partials/community_links.html
@@ -1,0 +1,33 @@
+{{ $links := .Site.Params.links -}}
+
+<section class="row td-box td-box--white td-box--height-auto linkbox">
+  <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+    <h2>{{ T "community_learn" }}</h2>
+    <p>{{ T "community_using" . }}</p>
+    {{ with index $links "user" -}}
+      {{ template "community-links-list" . -}}
+    {{ end }}
+  </div>
+  <div class="col-xs-12 col-sm-6 col-md-6 col-lg-6">
+    <h2>{{ T "community_develop" }}</h2>
+    <p>{{ T "community_contribute" . }}</p>
+    {{ with index $links "developer" -}}
+      {{ template "community-links-list" . -}}
+    {{ end }}
+    <p>
+      {{ T "community_how_to" . }}
+      <a href="/velocitas/docs/contribution-guidelines/">{{ T "community_guideline" }}</a>.
+    </p>
+  </div>
+</section>
+
+{{ define "community-links-list" -}}
+<ul>
+{{ range . -}}
+  <li title="{{ .name }}">
+    <a target="_blank" rel="noopener" href="{{ .url }}"><i class="{{ .icon }}"></i> {{ .name }}</a>:
+    {{ .desc }}
+  </li>
+{{ end }}
+</ul>
+{{- end }}


### PR DESCRIPTION
## Describe your changes

Need to add the partials layout for the community page and fix the hardcoded contribution guideline link there since even the docsy theme has it hardcoded there and we have to use the "/velocitas/" links because of the domain structure of https://websites.eclipseprojects.io/

Fixes https://github.com/eclipse-velocitas/velocitas-docs/issues/94

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code

