### PR TITLE
Fix contribution guideline link for official website and github pages

### DIFF
--- a/layouts/partials/community_links.html
+++ b/layouts/partials/community_links.html
@@ -16,7 +16,7 @@
     {{ end }}
     <p>
       {{ T "community_how_to" . }}
-      <a href="/velocitas/docs/contribution-guidelines/">{{ T "community_guideline" }}</a>.
+      <a href="../docs/contribution-guidelines/">{{ T "community_guideline" }}</a>.
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Describe your changes

This change fixes the weird behaviour of different page structure in official eclipse website and github pages

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code

