### PR TITLE
Adapt C++ docs to synced env var concept as used by Python SDK

### DIFF
--- a/content/en/docs/tutorials/vehicle_app_development/cpp_development.md
+++ b/content/en/docs/tutorials/vehicle_app_development/cpp_development.md
@@ -67,13 +67,13 @@ In your constructor, you have to choose which implementations to use for the Veh
 ```Cpp
 MyVehicleApp()
     : VehicleApp(IVehicleDataBrokerClient::createInstance("vehicledatabroker"), // this is the dapr-app-id of the KUKSA Databroker in the VAL.
-                 IPubSubClient::createInstance("localhost:1883", "MyVehicleApp")) // the URI to the MQTT broker and the client ID of the MQTT client.
+                 IPubSubClient::createInstance("MyVehicleApp")) // the client ID of the MQTT client.
     {}
 {}
 ```
 
 {{% alert title="Note" %}}
-The URI of the MQTT broker can also be set via the environment variable `MQTT_BROKER_URI`, which would overwrite the setting in the code. So make sure that you don't mix this up.
+The URI of the MQTT broker is by default `localhost:1883` and can be set to something else via the environment variable `SDV_MQTT_ADDRESS` (beginning with C++ SDK v0.3.3) or `MQTT_BROKER_URI` (SDKs before v0.3.3).
 {{% /alert %}}
 
 Now, you have initialized the app and can continue developing relevant methods.

--- a/content/en/docs/tutorials/vehicle_app_development/cpp_development.md
+++ b/content/en/docs/tutorials/vehicle_app_development/cpp_development.md
@@ -67,13 +67,15 @@ In your constructor, you have to choose which implementations to use for the Veh
 ```Cpp
 MyVehicleApp()
     : VehicleApp(IVehicleDataBrokerClient::createInstance("vehicledatabroker"), // this is the dapr-app-id of the KUKSA Databroker in the VAL.
-                 IPubSubClient::createInstance("MyVehicleApp")) // the client ID of the MQTT client.
+                 IPubSubClient::createInstance("MyVehicleApp")) // the clientId identifies the client at the pub/sub broker
     {}
 {}
 ```
 
 {{% alert title="Note" %}}
-The URI of the MQTT broker is by default `localhost:1883` and can be set to something else via the environment variable `SDV_MQTT_ADDRESS` (beginning with C++ SDK v0.3.3) or `MQTT_BROKER_URI` (SDKs before v0.3.3).
+The middleware abstraction of the C++ SDK is incomplete: Pub/sub abstraction is just supporting MQTT, currently.
+
+The URI of the MQTT broker is by default `localhost:1883` and can be set to another address via the environment variable `SDV_MQTT_ADDRESS` (beginning with C++ SDK v0.3.3) or `MQTT_BROKER_URI` (SDKs before v0.3.3).
 {{% /alert %}}
 
 Now, you have initialized the app and can continue developing relevant methods.

--- a/content/en/docs/tutorials/vehicle_app_development/cpp_development.md
+++ b/content/en/docs/tutorials/vehicle_app_development/cpp_development.md
@@ -73,7 +73,7 @@ MyVehicleApp()
 ```
 
 {{% alert title="Note" %}}
-The middleware abstraction of the C++ SDK is incomplete: Pub/sub abstraction is just supporting MQTT, currently.
+The middleware abstraction of the C++ SDK is incomplete: Pub/sub abstraction is just supporting MQTT (but no Dapr pub/sub), currently.
 
 The URI of the MQTT broker is by default `localhost:1883` and can be set to another address via the environment variable `SDV_MQTT_ADDRESS` (beginning with C++ SDK v0.3.3) or `MQTT_BROKER_URI` (SDKs before v0.3.3).
 {{% /alert %}}


### PR DESCRIPTION
## Describe your changes

Python SDK uses the `SDV_[service-name]_ADDRESS` for telling the address of the respective service to the application if using the native middleware. This shall be used for C++ also.

## Issue ticket number and link

Required by https://github.com/eclipse-velocitas/vehicle-app-cpp-sdk/issues/59

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

